### PR TITLE
Add support for custom color palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ function AddressIcon({ address }: { address: `0x${string}` }) {
 ## API
 
 <details>
-<summary><b><code>blo(address: Address, size = 64): string</code></b></summary>
+<summary><b><code>blo(address: Address, size = 64, palette?: Palette): string</code></b></summary>
 <br>
 
 Get a data URI string representing the identicon as an SVG image.
 
-The `size` paramater shouldn’t usually be needed, as the image will stay sharp no matter what the size of the `img` element is.
+The `size` parameter shouldn’t usually be needed, as the image will stay sharp no matter what the size of the `img` element is.
 
 Example:
 
@@ -79,10 +79,23 @@ img.src = blo(address); // size inside the SVG defaults to 64px
 img2.src = blo(address, 24); // set it to 24px
 ```
 
+Use the optional `palette` parameter to customize image colors.
+
+Example:
+
+```ts
+import { blo, hsl } from "blo";
+
+img.src = blo(address, 64, [
+  hsl(206, 100, 94), // background
+  hsl(167, 80, 45),  // color
+  hsl(345, 88, 35)   // spot
+]);
+```
 </details>
 
 <details>
-<summary><b><code>bloSvg(address: Address, size = 64): string</code></b></summary>
+<summary><b><code>bloSvg(address: Address, size = 64, palette?: Palette): string</code></b></summary>
 <br>
 
 Same as above except it returns the SVG code instead of a data URI string.
@@ -90,7 +103,7 @@ Same as above except it returns the SVG code instead of a data URI string.
 </details>
 
 <details>
-<summary><b><code>bloImage(address: Address): BloImage</code></b></summary>
+<summary><b><code>bloImage(address: Address, palette?: Palette): BloImage</code></b></summary>
 <br>
 
 Get a `BloImage` data structure that can be used to render the image in different formats.

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,18 +1,18 @@
-import type { Address, BloImage, BloImageData, Hsl, PaletteIndex } from "./types";
+import type { Address, BloImage, BloImageData, Hsl, Palette, PaletteIndex } from "./types";
 
 import { seedRandom } from "./random";
 
 // The random() calls must happen in this exact order:
-// 1. palette: main color (6 calls)
-// 2. palette: background (6 calls)
-// 3. palette: spot color (6 calls)
+// 1. palette: main color (6 calls, if no custom palette)
+// 2. palette: background (6 calls, if no custom palette)
+// 3. palette: spot color (6 calls, if no custom palette)
 // 4. image data (32 calls)
 
-export function image(address: Address): BloImage {
+export function image(address: Address, palette?: Palette): BloImage {
   const random = seedRandom(address.toLowerCase());
-  const palette = randomPalette(random);
+  const selectedPalette = palette ?? randomPalette(random);
   const data = randomImageData(random);
-  return [data, palette];
+  return [data, selectedPalette];
 }
 
 export function randomImageData(random: () => number): BloImageData {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Address, BloImage } from "./types";
+import type { Address, BloImage, Hsl, Palette } from "./types";
 
 import { image } from "./image";
 import { svg } from "./svg";
@@ -12,14 +12,18 @@ export type {
   PaletteIndex,
 } from "./types";
 
-export function blo(address: Address, size: number = 64): string {
-  return "data:image/svg+xml;base64," + btoa(bloSvg(address, size));
+export function blo(address: Address, size: number = 64, pallette?: Palette): string {
+  return "data:image/svg+xml;base64," + btoa(bloSvg(address, size, pallette));
 }
 
-export function bloSvg(address: Address, size: number = 64): string {
-  return svg(address, size);
+export function bloSvg(address: Address, size: number = 64, palette?: Palette): string {
+  return svg(address, size, palette);
 }
 
-export function bloImage(address: Address): BloImage {
-  return image(address);
+export function bloImage(address: Address, palette?: Palette): BloImage {
+  return image(address, palette);
+}
+
+export function hsl(hue: number, saturation: number, lightness: number): Hsl {
+  return Uint16Array.from([hue, saturation, lightness]);
 }

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -1,4 +1,4 @@
-import type { Address } from "./types";
+import type { Address, Palette } from "./types";
 
 import { randomPalette } from "./image";
 import { seedRandom } from "./random";
@@ -8,10 +8,10 @@ const SVG_START = `<svg `
   + `viewBox="0 0 8 8" `
   + `shape-rendering="optimizeSpeed" `; // optimizeSpeed stays sharp thanks to using <path />
 
-export function svg(address: Address, size: number) {
+export function svg(address: Address, size: number, pallette?: Palette) {
   const random = seedRandom(address.toLowerCase());
 
-  const [b, c, s] = randomPalette(random);
+  const [b, c, s] = pallette ?? randomPalette(random);
 
   const paths = [
     `M0,0H8V8H0z`, // background


### PR DESCRIPTION
Hi! This PR adds support for custom color palettes in a backwards compatible way. Some wallets/apps want to have control over the colors of the identicons to match the UI colors. 

<img width="797" alt="Screenshot 2025-02-26 at 17 05 33" src="https://github.com/user-attachments/assets/133b03f1-5ace-4f6c-a886-b96b2927c0d8" />

# Implementation details
* Added `palette` optional parameter to `blo`, `bloSvg`, `bloImage`, `svg` and `image` functions.
* Followed the exact same approach as `@download/blockies` package, in the presence of a custom palette, then ignore palette `random` calls and start generating image data from the fist call.
* Added the `hsl` utility function, which is just a syntax sugar for `Uint16Array.from([hue, saturation, lightness])`, to make the identicon construction clearer.
* Documented new parameter in the `README.md` file.

# API usage example

```ts
import { blo, hsl } from "blo";

img.src = blo(address, 64, [
  hsl(206, 100, 94), // background
  hsl(167, 80, 45),  // color
  hsl(345, 88, 35)   // spot
]);
```

---
I hope this can be merged so that I can use your amazing package in [Nautilus Wallet](https://github.com/nautls/nautilus-wallet). If additional changes/clarifications are needed, just let me know. :)